### PR TITLE
rawbit: update dependencies

### DIFF
--- a/rawbit/.SRCINFO
+++ b/rawbit/.SRCINFO
@@ -1,14 +1,13 @@
 pkgbase = rawbit
 	pkgdesc = A camera RAW photo preprocessor and importer
 	pkgver = 0.1.11
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/cartercanedy/rawbit
 	arch = x86_64
 	license = MIT
 	makedepends = rustup
-	makedepends = glibc
-	makedepends = gcc-libs
-	depends = libraw
+	depends = libiconv
+	depends = gcc-libs
 	source = rawbit-0.1.11.tar.gz::https://github.com/cartercanedy/rawbit/archive/v0.1.11.tar.gz
 	sha256sums = 3da1d199335149dcb73352aef3f6ab8b8e00e94e5671c644c9b5619ad4246a56
 

--- a/rawbit/PKGBUILD
+++ b/rawbit/PKGBUILD
@@ -2,15 +2,15 @@
 # https://github.com/adamperkowski/PKGBUILDs
 pkgname=rawbit
 pkgver=0.1.11
-pkgrel=1
+pkgrel=2
 pkgdesc='A camera RAW photo preprocessor and importer'
 arch=('x86_64')
 url="https://github.com/cartercanedy/$pkgname"
 license=('MIT')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
 sha256sums=('3da1d199335149dcb73352aef3f6ab8b8e00e94e5671c644c9b5619ad4246a56')
-makedepends=('rustup' 'glibc' 'gcc-libs')
-depends=('libraw')
+makedepends=('rustup')
+depends=('libiconv' 'gcc-libs')
 
 prepare() {
     export RUSTUP_TOOLCHAIN=stable


### PR DESCRIPTION
`rawbit` doesn't depend on `libraw` directly, since it uses a pure-Rust solution for RAW manipulation. I'm fairly certain that it's not pulled in by any other indirect deps, just based on `ldd` output. It does load `libiconv`, `libc` and `libgcc_s` dynamically, though, so I made those runtime deps instead of build-only deps.