### PR TITLE
cloudip: fix cloudip version

### DIFF
--- a/cloudip/.SRCINFO
+++ b/cloudip/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cloudip
 	pkgdesc = CLI tool for identifying cloud providers
 	pkgver = 0.3.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/jongwoo328/cloudip
 	arch = x86_64
 	license = Apache-2.0

--- a/cloudip/PKGBUILD
+++ b/cloudip/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=cloudip
 pkgver=0.3.0
-pkgrel=1
+pkgrel=2
 pkgdesc='CLI tool for identifying cloud providers'
 arch=('x86_64')
 url="https://github.com/jongwoo328/$pkgname"
@@ -26,7 +26,10 @@ build() {
   export CGO_LDFLAGS="$LDFLAGS"
   export GOPATH="$srcdir"
   export GOFLAGS='-buildmode=pie -mod=readonly -modcacherw'
-  go build -o "build/$pkgname" .
+  go build \
+    -ldflags "-X 'cloudip/cmd.Version=$pkgver'" \
+    -o "build/$pkgname" \
+    .
 }
 
 check() {


### PR DESCRIPTION
Version string of `cloudip` is injected from [Makefile](https://github.com/jongwoo328/cloudip/blob/main/Makefile) using `-ldflags`.
As a result, the version command in the cloudip package on AUR currently cannot print the version.
I'm not entirely sure how the PKGBUILD works, but it seems that adding the missing flags would resolve the issue in this case.
